### PR TITLE
PyModuleDef.m_reload was removed in Python 3.5

### DIFF
--- a/pytun.c
+++ b/pytun.c
@@ -757,7 +757,11 @@ static struct PyModuleDef pytun_module =
     .m_doc = NULL,
     .m_size = -1,
     .m_methods = NULL,
+#if PY_MINOR_VERSION <= 4
     .m_reload = NULL,
+#else
+    .m_slots = NULL,
+#endif
     .m_traverse = NULL,
     .m_clear = NULL,
     .m_free = NULL


### PR DESCRIPTION
Compilation with Python 3.5 fails with `pytun.c:760:5: error: unknown field ‘m_reload’ specified in initializer`.