### PR TITLE
Fixed DeprecationWarning

### DIFF
--- a/pytun.c
+++ b/pytun.c
@@ -1,3 +1,4 @@
+#define PY_SSIZE_T_CLEAN
 #include <Python.h>
 #include <string.h>
 #include <unistd.h>


### PR DESCRIPTION
Fixed DeprecationWarning: PY_SSIZE_T_CLEAN will be required for '#' formats
52. https://docs.python.org/3/c-api/intro.html#include-files