### PR TITLE
Add build CI workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,51 @@
+name: Build
+
+on: [push, pull_request, workflow_dispatch]
+
+jobs:
+  build_wheels:
+    name: Build wheels
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Build wheels
+        uses: pypa/cibuildwheel@v2.10.2
+        env:
+          CIBW_BUILD: cp36-* cp37-* cp38-* cp39-* cp310-* cp311-*
+          CIBW_ARCHS: auto64
+
+      - uses: actions/upload-artifact@v3
+        with:
+          path: ./wheelhouse/*.whl
+
+  build_legacy_wheels:
+    name: Build legacy wheels
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Build wheels
+        uses: pypa/cibuildwheel@v1.12.0
+        env:
+          CIBW_BUILD: cp27-* cp35-*
+          CIBW_ARCHS: auto64
+
+      - uses: actions/upload-artifact@v3
+        with:
+          path: ./wheelhouse/*.whl
+
+  build_sdist:
+    name: Build source distribution
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Build sdist
+        run: pipx run build --sdist
+
+      - uses: actions/upload-artifact@v3
+        with:
+          path: dist/*.tar.gz


### PR DESCRIPTION
This adds a workflow to automate the build process for a release.
Only takes 2 minutes to run in GitHub Actions :)

This workflow should retain the currently-provided PyPI wheels (omitting some redundant wheels thanks to 'compressed' tags for 3.6+ wheels), and add 3.10, 3.11 and musllinux wheels.

Artifacts list:
```
python_pytun-2.4.1-cp27-cp27m-manylinux1_x86_64.whl
python_pytun-2.4.1-cp27-cp27m-manylinux2010_x86_64.whl
python_pytun-2.4.1-cp27-cp27mu-manylinux1_x86_64.whl
python_pytun-2.4.1-cp27-cp27mu-manylinux2010_x86_64.whl
python_pytun-2.4.1-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl
python_pytun-2.4.1-cp310-cp310-musllinux_1_1_x86_64.whl
python_pytun-2.4.1-cp311-cp311-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl
python_pytun-2.4.1-cp311-cp311-musllinux_1_1_x86_64.whl
python_pytun-2.4.1-cp35-cp35m-manylinux1_x86_64.whl
python_pytun-2.4.1-cp35-cp35m-manylinux2010_x86_64.whl
python_pytun-2.4.1-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl
python_pytun-2.4.1-cp36-cp36m-musllinux_1_1_x86_64.whl
python_pytun-2.4.1-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl
python_pytun-2.4.1-cp37-cp37m-musllinux_1_1_x86_64.whl
python_pytun-2.4.1-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl
python_pytun-2.4.1-cp38-cp38-musllinux_1_1_x86_64.whl
python_pytun-2.4.1-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl
python_pytun-2.4.1-cp39-cp39-musllinux_1_1_x86_64.whl
python-pytun-2.4.1.tar.gz
```

Would be cool to upload `3.10, 3.11, musllinux` wheels to PyPI as part of the current release :)
Related to #22 