### PR TITLE
ci: update wheels build (cp312, cp312)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,9 +11,9 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.10.2
+        uses: pypa/cibuildwheel@v2.22.0
         env:
-          CIBW_BUILD: cp36-* cp37-* cp38-* cp39-* cp310-* cp311-*
+          CIBW_BUILD: cp36-* cp37-* cp38-* cp39-* cp310-* cp311-* cp312-* cp313-*
           CIBW_ARCHS: auto64
 
       - uses: actions/upload-artifact@v3


### PR DESCRIPTION
* bumped cibuildwheel to 2.22.0
* added cp312 and cp313 builds