### PR TITLE
ci: update wheels build for cp314

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,9 +11,9 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.22.0
+        uses: pypa/cibuildwheel@v3.3.0
         env:
-          CIBW_BUILD: cp36-* cp37-* cp38-* cp39-* cp310-* cp311-* cp312-* cp313-*
+          CIBW_BUILD: cp36-* cp37-* cp38-* cp39-* cp310-* cp311-* cp312-* cp313-* cp314-*
           CIBW_ARCHS: auto64
 
       - uses: actions/upload-artifact@v4


### PR DESCRIPTION
* bumped cibuildwheel to 3.3.0
* added cp314 builds